### PR TITLE
Keyboard handling (first cut)

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -36,8 +36,16 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
       Section(
         title: "",
         rows: [
-          TextField(placeholder: "bang", didChange: { textField in self.resource.text = textField.text }).toRow()
+          TextField(placeholder: "bang", didChange: { textField in self.resource.text = "\(self.resource.text ?? "")\(textField.text ?? "")" }).toRow(),
+          TextField(placeholder: "bong", didChange: { textField in self.resource.text = "\(self.resource.text ?? "")\(textField.text ?? "")" }).toRow(),
         ]
+      ),
+      Section(
+        title: "",
+        rows: [
+          Switch(text: "baz 2", didChange: { theSwitch in self.resource.isOn = theSwitch.isOn }).toRow(),
+          TextField(placeholder: "bong 2", didChange: { textField in self.resource.text = "\(self.resource.text ?? "")\(textField.text ?? "")" }).toRow(),
+          ]
       ),
       Section(
         title: "",

--- a/MinimalForms.xcodeproj/project.pbxproj
+++ b/MinimalForms.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		3F2C9FBE1E643BB000614CB5 /* SwitchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2C9FA61E643B5C00614CB5 /* SwitchCell.swift */; };
 		3F2C9FBF1E643BB000614CB5 /* TextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2C9FA71E643B5C00614CB5 /* TextField.swift */; };
 		3F2C9FC01E643BB000614CB5 /* TextFieldCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2C9FA81E643B5C00614CB5 /* TextFieldCell.swift */; };
+		3F78EDEE1E847B6F003006B0 /* FormKeyboardController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F78EDED1E847B6F003006B0 /* FormKeyboardController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +89,7 @@
 		3F2C9FA61E643B5C00614CB5 /* SwitchCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwitchCell.swift; path = Sources/MinimalForms/SwitchCell.swift; sourceTree = SOURCE_ROOT; };
 		3F2C9FA71E643B5C00614CB5 /* TextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TextField.swift; path = Sources/MinimalForms/TextField.swift; sourceTree = SOURCE_ROOT; };
 		3F2C9FA81E643B5C00614CB5 /* TextFieldCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TextFieldCell.swift; path = Sources/MinimalForms/TextFieldCell.swift; sourceTree = SOURCE_ROOT; };
+		3F78EDED1E847B6F003006B0 /* FormKeyboardController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FormKeyboardController.swift; path = Sources/MinimalForms/FormKeyboardController.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -147,6 +149,7 @@
 				3F2C9F9F1E643B5C00614CB5 /* Detail.swift */,
 				3F2C9FA01E643B5C00614CB5 /* DetailCell.swift */,
 				3F2C9FA11E643B5C00614CB5 /* FormController.swift */,
+				3F78EDED1E847B6F003006B0 /* FormKeyboardController.swift */,
 				3F2C9F581E63742300614CB5 /* Info.plist */,
 				3F2C9F5A1E63743100614CB5 /* MinimalForms.h */,
 				3F2C9FA21E643B5C00614CB5 /* Row.swift */,
@@ -330,6 +333,7 @@
 				3F2C9FB51E643BA600614CB5 /* Button.swift in Sources */,
 				3F2C9FBF1E643BB000614CB5 /* TextField.swift in Sources */,
 				3F2C9FB61E643BA600614CB5 /* ButtonCell.swift in Sources */,
+				3F78EDEE1E847B6F003006B0 /* FormKeyboardController.swift in Sources */,
 				3F2C9FB81E643BA600614CB5 /* DetailCell.swift in Sources */,
 				3F2C9FBD1E643BB000614CB5 /* Switch.swift in Sources */,
 				3F2C9FB71E643BA600614CB5 /* Detail.swift in Sources */,
@@ -776,6 +780,7 @@
 				3F2C9F891E6429B600614CB5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Sources/MinimalForms/FormController.swift
+++ b/Sources/MinimalForms/FormController.swift
@@ -15,9 +15,7 @@ public class FormController: NSObject, UITableViewDataSource, UITableViewDelegat
     tableView.delegate = self
 
     sections
-      .map { section in section.rows }
-      .joined()
-      .toArray()
+      .flatMap { $0.rows }
       .forEach { row in
         tableView.register(row.cellClass, forCellReuseIdentifier: row.identifier)
     }
@@ -49,12 +47,5 @@ public class FormController: NSObject, UITableViewDataSource, UITableViewDelegat
     let config = sections[indexPath.section].rows[indexPath.row]
 
     config.didSelect?()
-  }
-}
-
-extension FlattenBidirectionalCollection {
-
-  func toArray() -> Array<Base.Iterator.Element.Iterator.Element> {
-    return Array(self)
   }
 }

--- a/Sources/MinimalForms/FormController.swift
+++ b/Sources/MinimalForms/FormController.swift
@@ -1,10 +1,14 @@
 import UIKit
 
 public class FormController: NSObject, UITableViewDataSource, UITableViewDelegate {
+
   let sections: [Section]
+
+  let keyboardController: FormKeyboardController
 
   public init(sections: [Section], tableView: UITableView) {
     self.sections = sections
+    self.keyboardController = FormKeyboardController(formTableView: tableView)
     super.init()
 
     configure(tableView)
@@ -33,6 +37,11 @@ public class FormController: NSObject, UITableViewDataSource, UITableViewDelegat
     let config = sections[indexPath.section].rows[indexPath.row]
     let cell = tableView.dequeueReusableCell(withIdentifier: config.identifier, for: indexPath)
     config.configure(cell)
+
+    if let textField = (cell as? TextFieldCell)?.textField {
+      textField.inputAccessoryView = keyboardController.toolbar
+    }
+
     return cell
   }
 

--- a/Sources/MinimalForms/FormKeyboardController.swift
+++ b/Sources/MinimalForms/FormKeyboardController.swift
@@ -1,0 +1,73 @@
+import UIKit
+
+class FormKeyboardController {
+
+  private weak var tableView: UITableView?
+
+  public lazy var toolbar: UIToolbar = {
+    let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: self.tableView?.frame.size.width ?? 0, height: 50))
+    toolbar.barStyle = .default
+    toolbar.items = [
+      UIBarButtonItem(title: "<", style: UIBarButtonItemStyle.plain, target: self, action: #selector(previous)),
+      UIBarButtonItem(title: ">", style: UIBarButtonItemStyle.plain, target: self, action: #selector(next)),
+      UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.flexibleSpace, target: nil, action: nil),
+      UIBarButtonItem(title: "Done", style: UIBarButtonItemStyle.plain, target: self, action: #selector(done))]
+    toolbar.sizeToFit()
+    return toolbar
+  }()
+
+  public init(formTableView: UITableView) {
+    self.tableView = formTableView
+  }
+
+  @objc private func next() {
+    guard let firstResponder = self.firstResponder() else { return }
+
+    let textFields = orderedTextFields()
+
+    guard let index = textFields.index(of: firstResponder) else { return }
+
+    if index == textFields.count - 1 {
+      // this was the last text field
+      firstResponder.resignFirstResponder()
+    } else {
+      textFields[index + 1].becomeFirstResponder()
+    }
+  }
+  @objc private func previous() {
+    guard let firstResponder = self.firstResponder() else { return }
+
+    let textFields = orderedTextFields()
+
+    guard let index = textFields.index(of: firstResponder) else { return }
+
+    if index > 0 {
+      textFields[index - 1].becomeFirstResponder()
+    }
+  }
+  @objc private func done() {
+    guard let firstResponder = self.firstResponder() else { return }
+    firstResponder.resignFirstResponder()
+  }
+
+  private func orderedTextFields() -> [UITextField] {
+    guard let tableView = self.tableView else { preconditionFailure("Called \(#function) before the table view had been set") }
+    return extractTextFields(from: tableView)
+      .sorted(by: { tableView.convert($0.center, from: $0).y < tableView.convert($1.center, from: $1).y })
+  }
+
+  private func extractTextFields(from view: UIView) -> [UITextField] {
+    if let textField = view as? UITextField {
+      return [textField]
+    }
+    if view.subviews.count > 0 {
+      return view.subviews.flatMap { extractTextFields(from: $0) }
+    }
+    return []
+  }
+
+  private func firstResponder() -> UITextField? {
+    guard let tableView = self.tableView else { preconditionFailure("Called \(#function) before the table view had been set") }
+    return extractTextFields(from: tableView).first(where: { $0.isFirstResponder })
+  }
+}

--- a/Sources/MinimalForms/FormKeyboardController.swift
+++ b/Sources/MinimalForms/FormKeyboardController.swift
@@ -38,8 +38,11 @@ class FormKeyboardController {
       firstResponder.resignFirstResponder()
     } else {
       textFields[index + 1].becomeFirstResponder()
+
+      scrollTableToFirstResponderCell()
     }
   }
+
   @objc private func previous() {
     guard let firstResponder = self.firstResponder() else { return }
 
@@ -49,12 +52,17 @@ class FormKeyboardController {
 
     if index > 0 {
       textFields[index - 1].becomeFirstResponder()
+
+      scrollTableToFirstResponderCell()
     }
   }
+
   @objc private func done() {
     guard let firstResponder = self.firstResponder() else { return }
     firstResponder.resignFirstResponder()
   }
+
+  // MARK: -
 
   private func orderedTextFields() -> [UITextField] {
     guard let tableView = self.tableView else { preconditionFailure("Called \(#function) before the table view had been set") }
@@ -75,6 +83,17 @@ class FormKeyboardController {
   private func firstResponder() -> UITextField? {
     guard let tableView = self.tableView else { preconditionFailure("Called \(#function) before the table view had been set") }
     return extractTextFields(from: tableView).first(where: { $0.isFirstResponder })
+  }
+
+  // MARK: -
+
+  private func scrollTableToFirstResponderCell() {
+    guard let firstResponder = self.firstResponder() else { return }
+
+    guard let tableView = tableView else { return }
+    let point = tableView.convert(firstResponder.center, from: firstResponder)
+    guard let indexPath = tableView.indexPathForRow(at: point) else { return }
+    tableView.scrollToRow(at: indexPath, at: .middle, animated: true)
   }
 }
 


### PR DESCRIPTION
Add keyboard handling:

- [x] Keyboard toolbar with previous/next/done buttonr
- [x] Scroll to `firstResponder`s cell
  - [x] Update table view rect based on whether the keyboard is displayed or not, _so that the scroll actually works_

_Hooks are out of scope_.